### PR TITLE
fixed argument indices

### DIFF
--- a/StampIcon/main.swift
+++ b/StampIcon/main.swift
@@ -23,22 +23,24 @@ func generateConfigFromArguments() -> StampConfig {
             config.inputFile = argument
             continue
         }
-
+        
+        let argIdx = idx + 1
+        
         switch argument {
         case "--text":
-            config.text = Process.arguments[idx+1]
+            config.text = Process.arguments[argIdx+1]
 
         case "--output":
-            config.outputFile = Process.arguments[idx+1]
+            config.outputFile = Process.arguments[argIdx+1]
 
         case "--font":
-            config.fontName = Process.arguments[idx+1]
+            config.fontName = Process.arguments[argIdx+1]
 
         case "--textcolor":
-            config.textColor = NSColor(rgba: Process.arguments[idx+1])
+            config.textColor = NSColor(rgba: Process.arguments[argIdx+1])
 
         case "--badgecolor":
-            config.badgeColor = NSColor(rgba: Process.arguments[idx+1])
+            config.badgeColor = NSColor(rgba: Process.arguments[argIdx+1])
 
         default:
             continue


### PR DESCRIPTION
argument indices had an offset by 1

e.g. `stampicon Icon-60\@2x.png --text "app" --output newicon.png`

led to

`StampConfig(inputFile: "Icon-60@2x.png", outputFile: "--output", text: "--text", textColor: NSCalibratedWhiteColorSpace 1 1, badgeColor: NSCustomColorSpace sRGB IEC61966-2.1 colorspace 0.98 0.13 0.15 1, fontName: "Helvetica")`
